### PR TITLE
Used current class instead of generic UINavigationBar and UIToolbar t…

### DIFF
--- a/Pod/Classes/freestyle/src/Modules/UIModule/Controls/PXUINavigationBar.m
+++ b/Pod/Classes/freestyle/src/Modules/UIModule/Controls/PXUINavigationBar.m
@@ -248,7 +248,7 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
          {
              [UIBarButtonItem UpdateStyleWithRuleSetHandler:ruleSet
                                                     context:context
-                                                     target:[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil]];
+                                                     target:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]];
          }];
         
         barButtons.supportedPseudoClasses = BUTTONS_PSEUDOCLASS_MAP.allKeys;
@@ -261,12 +261,12 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
             PXShapeStyler.sharedInstance,
             PXBoxShadowStyler.sharedInstance,
 
-            [[PXFontStyler alloc] initWithCompletionBlock:[UIBarButtonItem FontStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil]]],
+            [[PXFontStyler alloc] initWithCompletionBlock:[UIBarButtonItem FontStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]],
             
-            [[PXPaintStyler alloc] initWithCompletionBlock:[UIBarButtonItem PXPaintStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil]]],
+            [[PXPaintStyler alloc] initWithCompletionBlock:[UIBarButtonItem PXPaintStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]],
 
             [[PXGenericStyler alloc] initWithHandlers: @{
-                @"-ios-tint-color" : [UIBarButtonItem TintColorDeclarationHandlerBlock:[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil]]
+                @"-ios-tint-color" : [UIBarButtonItem TintColorDeclarationHandlerBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]
                 }],
             ];
         
@@ -283,7 +283,7 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
              {
                  UIImage *image = context.backgroundImage;
                  
-                 [[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil]
+                 [[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]
                       setBackButtonBackgroundImage:image
                       forState:[context stateFromStateNameMap:BUTTONS_PSEUDOCLASS_MAP]
                       barMetrics:UIBarMetricsDefault];

--- a/Pod/Classes/freestyle/src/Modules/UIModule/Controls/PXUIToolbar.m
+++ b/Pod/Classes/freestyle/src/Modules/UIModule/Controls/PXUIToolbar.m
@@ -82,7 +82,7 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
          {
              [UIBarButtonItem UpdateStyleWithRuleSetHandler:ruleSet
                                                     context:context
-                                                     target:[UIBarButtonItem appearanceWhenContainedIn:[UIToolbar class], nil]];
+                                                     target:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]];
          }];
         
         barButtons.supportedPseudoClasses = BUTTONS_PSEUDOCLASS_MAP.allKeys;
@@ -95,12 +95,12 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
                                    PXShapeStyler.sharedInstance,
                                    PXBoxShadowStyler.sharedInstance,
                                    
-                                   [[PXFontStyler alloc] initWithCompletionBlock:[UIBarButtonItem FontStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[UIToolbar class], nil]]],
+                                   [[PXFontStyler alloc] initWithCompletionBlock:[UIBarButtonItem FontStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]],
                                    
-                                   [[PXPaintStyler alloc] initWithCompletionBlock:[UIBarButtonItem PXPaintStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[UIToolbar class], nil]]],
+                                   [[PXPaintStyler alloc] initWithCompletionBlock:[UIBarButtonItem PXPaintStylerCompletionBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]],
                                    
                                    [[PXGenericStyler alloc] initWithHandlers: @{
-                                        @"-ios-tint-color" : [UIBarButtonItem TintColorDeclarationHandlerBlock:[UIBarButtonItem appearanceWhenContainedIn:[UIToolbar class], nil]]
+                                        @"-ios-tint-color" : [UIBarButtonItem TintColorDeclarationHandlerBlock:[UIBarButtonItem appearanceWhenContainedIn:[self class], nil]]
                                         }],
                                    ];
         children = @[ barButtons ];


### PR DESCRIPTION
…o prevent global overrides that affect unstyled instances
- Note: still not perfect solution as requires app to have custom navigation/tool bar class just to bypass this issue
