### PR TITLE
added style control methods to UIView StylingKit

### DIFF
--- a/Pod/Classes/Main/StylingKit.h
+++ b/Pod/Classes/Main/StylingKit.h
@@ -49,4 +49,13 @@
 @property (nonatomic, copy) IBInspectable NSString *styleClass;
 @property (nonatomic, copy) IBInspectable NSString *styleCSS;
 
+- (void)updateStyles;
+- (void)updateStylesNonRecursively;
+- (void)updateStylesAsync;
+- (void)updateStylesNonRecursivelyAsync;
+
+- (void)addStyleClass:(NSString *)styleClass;
+- (void)removeStyleClass:(NSString *)styleClass;
+- (void)styleClassed:(NSString *)styleClass enabled:(bool)enabled;
+
 @end


### PR DESCRIPTION
StylingKit.h exposes only the class properties from the UIView+PXStyling.h not the methods to update the styles

In ObjectiveC I imported UIView+PXStyling.h to use them, in Swift I need them in StylingKit.h